### PR TITLE
NodesBucket should be non empty string for query language

### DIFF
--- a/netgraph/policy.go
+++ b/netgraph/policy.go
@@ -16,7 +16,7 @@ const (
 	Separator   = "/"
 
 	// NodesBucket is the name for optionless bucket containing only nodes.
-	NodesBucket = ""
+	NodesBucket = "Node"
 )
 
 type (


### PR DESCRIPTION
If we are going to use query language for specifying policies, then we need non-empty bucket-type constant for leafs (nodes). Empty bucket-type constant is senseless in terms of query language. 

There is no need to change fixtures
```
>>> select 1 Country
>>> filter Location NE Asia
>>> get-selection
[11 12]
```
