### PR TITLE
add Exclude to SFGroup

### DIFF
--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -154,7 +154,8 @@ func write(b *netmap.Bucket, name string) error {
 
 func getSelection(c *ishell.Context) {
 	s := getState(c)
-	if b := s.b.GetMaxSelection(s.ss, s.fs); b != nil {
+	b := s.b.GetMaxSelection(netmap.SFGroup{Selectors: s.ss, Filters: s.fs})
+	if b != nil {
 		if b = b.GetSelection(s.ss, defaultSource); b != nil {
 			c.Println(b.Nodelist())
 			return
@@ -185,7 +186,8 @@ func dumpNetmap(c *ishell.Context) {
 			return
 		}
 	}
-	if b := s.b.GetMaxSelection(s.ss, s.fs); b != nil {
+	b := s.b.GetMaxSelection(netmap.SFGroup{Selectors: s.ss, Filters: s.fs})
+	if b != nil {
 		if b = b.GetSelection(s.ss, defaultSource); b != nil {
 			if err := s.b.DumpWithSelection(c.Args[0], *b); err != nil {
 				c.Err(err)

--- a/selector.pb.go
+++ b/selector.pb.go
@@ -3,13 +3,12 @@
 
 package netmap
 
-import (
-	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/golang/protobuf/proto"
-	io "io"
-	math "math"
-)
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import _ "github.com/gogo/protobuf/gogoproto"
+
+import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -47,7 +46,6 @@ var Operation_name = map[int32]string{
 	7: "OR",
 	8: "AND",
 }
-
 var Operation_value = map[string]int32{
 	"NP":  0,
 	"EQ":  1,
@@ -63,9 +61,8 @@ var Operation_value = map[string]int32{
 func (x Operation) String() string {
 	return proto.EnumName(Operation_name, int32(x))
 }
-
 func (Operation) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{0}
+	return fileDescriptor_selector_514e26064bb83725, []int{0}
 }
 
 type Type int32
@@ -79,7 +76,6 @@ var Type_name = map[int32]string{
 	0: "String",
 	1: "Integer",
 }
-
 var Type_value = map[string]int32{
 	"String":  0,
 	"Integer": 1,
@@ -88,14 +84,13 @@ var Type_value = map[string]int32{
 func (x Type) String() string {
 	return proto.EnumName(Type_name, int32(x))
 }
-
 func (Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{1}
+	return fileDescriptor_selector_514e26064bb83725, []int{1}
 }
 
 type PlacementRule struct {
 	ReplFactor           uint32    `protobuf:"varint,1,opt,name=ReplFactor,proto3" json:"ReplFactor,omitempty"`
-	SFGroups             []SFGroup `protobuf:"bytes,2,rep,name=SFGroups,proto3" json:"SFGroups"`
+	SFGroups             []SFGroup `protobuf:"bytes,2,rep,name=SFGroups" json:"SFGroups"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -105,7 +100,7 @@ func (m *PlacementRule) Reset()         { *m = PlacementRule{} }
 func (m *PlacementRule) String() string { return proto.CompactTextString(m) }
 func (*PlacementRule) ProtoMessage()    {}
 func (*PlacementRule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{0}
+	return fileDescriptor_selector_514e26064bb83725, []int{0}
 }
 func (m *PlacementRule) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -122,8 +117,8 @@ func (m *PlacementRule) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-func (m *PlacementRule) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PlacementRule.Merge(m, src)
+func (dst *PlacementRule) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PlacementRule.Merge(dst, src)
 }
 func (m *PlacementRule) XXX_Size() int {
 	return m.Size()
@@ -149,8 +144,9 @@ func (m *PlacementRule) GetSFGroups() []SFGroup {
 }
 
 type SFGroup struct {
-	Filters              []Filter `protobuf:"bytes,1,rep,name=Filters,proto3" json:"Filters"`
-	Selectors            []Select `protobuf:"bytes,2,rep,name=Selectors,proto3" json:"Selectors"`
+	Filters              []Filter `protobuf:"bytes,1,rep,name=Filters" json:"Filters"`
+	Selectors            []Select `protobuf:"bytes,2,rep,name=Selectors" json:"Selectors"`
+	Exclude              []uint32 `protobuf:"varint,3,rep,packed,name=Exclude" json:"Exclude,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -160,7 +156,7 @@ func (m *SFGroup) Reset()         { *m = SFGroup{} }
 func (m *SFGroup) String() string { return proto.CompactTextString(m) }
 func (*SFGroup) ProtoMessage()    {}
 func (*SFGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{1}
+	return fileDescriptor_selector_514e26064bb83725, []int{1}
 }
 func (m *SFGroup) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -177,8 +173,8 @@ func (m *SFGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *SFGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SFGroup.Merge(m, src)
+func (dst *SFGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SFGroup.Merge(dst, src)
 }
 func (m *SFGroup) XXX_Size() int {
 	return m.Size()
@@ -203,6 +199,13 @@ func (m *SFGroup) GetSelectors() []Select {
 	return nil
 }
 
+func (m *SFGroup) GetExclude() []uint32 {
+	if m != nil {
+		return m.Exclude
+	}
+	return nil
+}
+
 type Select struct {
 	Count                uint32   `protobuf:"varint,1,opt,name=Count,proto3" json:"Count,omitempty"`
 	Key                  string   `protobuf:"bytes,2,opt,name=Key,proto3" json:"Key,omitempty"`
@@ -215,7 +218,7 @@ func (m *Select) Reset()         { *m = Select{} }
 func (m *Select) String() string { return proto.CompactTextString(m) }
 func (*Select) ProtoMessage()    {}
 func (*Select) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{2}
+	return fileDescriptor_selector_514e26064bb83725, []int{2}
 }
 func (m *Select) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -232,8 +235,8 @@ func (m *Select) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *Select) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Select.Merge(m, src)
+func (dst *Select) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Select.Merge(dst, src)
 }
 func (m *Select) XXX_Size() int {
 	return m.Size()
@@ -259,7 +262,7 @@ func (m *Select) GetKey() string {
 }
 
 type SimpleFilters struct {
-	Filters              []SimpleFilter `protobuf:"bytes,1,rep,name=Filters,proto3" json:"Filters"`
+	Filters              []SimpleFilter `protobuf:"bytes,1,rep,name=Filters" json:"Filters"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -269,7 +272,7 @@ func (m *SimpleFilters) Reset()         { *m = SimpleFilters{} }
 func (m *SimpleFilters) String() string { return proto.CompactTextString(m) }
 func (*SimpleFilters) ProtoMessage()    {}
 func (*SimpleFilters) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{3}
+	return fileDescriptor_selector_514e26064bb83725, []int{3}
 }
 func (m *SimpleFilters) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -286,8 +289,8 @@ func (m *SimpleFilters) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-func (m *SimpleFilters) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleFilters.Merge(m, src)
+func (dst *SimpleFilters) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleFilters.Merge(dst, src)
 }
 func (m *SimpleFilters) XXX_Size() int {
 	return m.Size()
@@ -320,7 +323,7 @@ func (m *SimpleFilter) Reset()         { *m = SimpleFilter{} }
 func (m *SimpleFilter) String() string { return proto.CompactTextString(m) }
 func (*SimpleFilter) ProtoMessage()    {}
 func (*SimpleFilter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{4}
+	return fileDescriptor_selector_514e26064bb83725, []int{4}
 }
 func (m *SimpleFilter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -337,8 +340,8 @@ func (m *SimpleFilter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (m *SimpleFilter) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleFilter.Merge(m, src)
+func (dst *SimpleFilter) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleFilter.Merge(dst, src)
 }
 func (m *SimpleFilter) XXX_Size() int {
 	return m.Size()
@@ -359,7 +362,7 @@ type SimpleFilter_Value struct {
 	Value string `protobuf:"bytes,2,opt,name=Value,proto3,oneof"`
 }
 type SimpleFilter_FArgs struct {
-	FArgs *SimpleFilters `protobuf:"bytes,3,opt,name=FArgs,proto3,oneof"`
+	FArgs *SimpleFilters `protobuf:"bytes,3,opt,name=FArgs,oneof"`
 }
 
 func (*SimpleFilter_Value) isSimpleFilter_Args() {}
@@ -465,7 +468,7 @@ func _SimpleFilter_OneofSizer(msg proto.Message) (n int) {
 
 type Filter struct {
 	Key                  string        `protobuf:"bytes,1,opt,name=Key,proto3" json:"Key,omitempty"`
-	F                    *SimpleFilter `protobuf:"bytes,2,opt,name=F,proto3" json:"F,omitempty"`
+	F                    *SimpleFilter `protobuf:"bytes,2,opt,name=F" json:"F,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -475,7 +478,7 @@ func (m *Filter) Reset()         { *m = Filter{} }
 func (m *Filter) String() string { return proto.CompactTextString(m) }
 func (*Filter) ProtoMessage()    {}
 func (*Filter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e4729c7385e2dd96, []int{5}
+	return fileDescriptor_selector_514e26064bb83725, []int{5}
 }
 func (m *Filter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -492,8 +495,8 @@ func (m *Filter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *Filter) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Filter.Merge(m, src)
+func (dst *Filter) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Filter.Merge(dst, src)
 }
 func (m *Filter) XXX_Size() int {
 	return m.Size()
@@ -519,50 +522,15 @@ func (m *Filter) GetF() *SimpleFilter {
 }
 
 func init() {
-	proto.RegisterEnum("netmap.Operation", Operation_name, Operation_value)
-	proto.RegisterEnum("netmap.Type", Type_name, Type_value)
 	proto.RegisterType((*PlacementRule)(nil), "netmap.PlacementRule")
 	proto.RegisterType((*SFGroup)(nil), "netmap.SFGroup")
 	proto.RegisterType((*Select)(nil), "netmap.Select")
 	proto.RegisterType((*SimpleFilters)(nil), "netmap.SimpleFilters")
 	proto.RegisterType((*SimpleFilter)(nil), "netmap.SimpleFilter")
 	proto.RegisterType((*Filter)(nil), "netmap.Filter")
+	proto.RegisterEnum("netmap.Operation", Operation_name, Operation_value)
+	proto.RegisterEnum("netmap.Type", Type_name, Type_value)
 }
-
-func init() { proto.RegisterFile("selector.proto", fileDescriptor_e4729c7385e2dd96) }
-
-var fileDescriptor_e4729c7385e2dd96 = []byte{
-	// 446 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x52, 0xc1, 0x6e, 0xd3, 0x40,
-	0x10, 0xf5, 0xda, 0x89, 0xdd, 0x4c, 0x48, 0x58, 0x56, 0x05, 0x59, 0x1c, 0xdc, 0xe0, 0x53, 0x54,
-	0xa9, 0x2e, 0x04, 0xce, 0x48, 0x0d, 0xd8, 0x05, 0x81, 0x9a, 0xb2, 0x89, 0xb8, 0x3b, 0xd1, 0x62,
-	0x2c, 0xd9, 0xde, 0x95, 0xbd, 0x3e, 0xf4, 0xc6, 0x67, 0xf0, 0x49, 0x3d, 0xf2, 0x05, 0x08, 0x85,
-	0x1f, 0x41, 0x5e, 0xaf, 0x4d, 0x14, 0xc1, 0xe9, 0xcd, 0x9b, 0x79, 0x6f, 0xdf, 0x8c, 0xb4, 0x30,
-	0xad, 0x58, 0xc6, 0x76, 0x92, 0x97, 0x81, 0x28, 0xb9, 0xe4, 0xc4, 0x2e, 0x98, 0xcc, 0x63, 0xf1,
-	0xf4, 0x22, 0x49, 0xe5, 0xd7, 0x7a, 0x1b, 0xec, 0x78, 0x7e, 0x99, 0xf0, 0x84, 0x5f, 0xaa, 0xf1,
-	0xb6, 0xfe, 0xa2, 0x98, 0x22, 0xaa, 0x6a, 0x6d, 0xfe, 0x16, 0x26, 0xb7, 0x59, 0xbc, 0x63, 0x39,
-	0x2b, 0x24, 0xad, 0x33, 0x46, 0x3c, 0x00, 0xca, 0x44, 0x16, 0xc5, 0xcd, 0xdb, 0x2e, 0x9a, 0xa1,
-	0xf9, 0x84, 0x1e, 0x74, 0xc8, 0x0b, 0x38, 0x59, 0x47, 0xd7, 0x25, 0xaf, 0x45, 0xe5, 0x9a, 0x33,
-	0x6b, 0x3e, 0x5e, 0x3c, 0x0c, 0xda, 0xe8, 0x40, 0xf7, 0x97, 0x83, 0xfb, 0x9f, 0x67, 0x06, 0xed,
-	0x65, 0x7e, 0x0e, 0x8e, 0xae, 0x49, 0x00, 0x4e, 0x94, 0x66, 0x92, 0x95, 0x95, 0x8b, 0x94, 0x79,
-	0xda, 0x99, 0xdb, 0xb6, 0xf6, 0x76, 0x22, 0xb2, 0x80, 0xd1, 0x5a, 0xdf, 0xd9, 0xc5, 0xf5, 0x8e,
-	0x76, 0xa0, 0x1d, 0x7f, 0x65, 0xfe, 0x73, 0xb0, 0x5b, 0x42, 0x4e, 0x61, 0xf8, 0x86, 0xd7, 0x85,
-	0xd4, 0x67, 0xb4, 0x84, 0x60, 0xb0, 0x3e, 0xb0, 0x3b, 0xd7, 0x9c, 0xa1, 0xf9, 0x88, 0x36, 0xa5,
-	0x1f, 0xc2, 0x64, 0x9d, 0xe6, 0x22, 0x63, 0x5d, 0xec, 0xab, 0xe3, 0x35, 0x4f, 0xfb, 0xd0, 0x03,
-	0xdd, 0xd1, 0xb2, 0xfe, 0x37, 0x04, 0x0f, 0x0e, 0xe7, 0xe4, 0x19, 0x98, 0x2b, 0xa1, 0xc2, 0xa7,
-	0x8b, 0x47, 0xdd, 0x0b, 0x2b, 0xc1, 0xca, 0x58, 0xa6, 0xbc, 0xa0, 0xe6, 0x4a, 0x90, 0x27, 0x30,
-	0xfc, 0x1c, 0x67, 0x35, 0x6b, 0xd7, 0x79, 0x67, 0xd0, 0x96, 0x92, 0x0b, 0x18, 0x46, 0x57, 0x65,
-	0x52, 0xb9, 0xd6, 0x0c, 0xcd, 0xc7, 0x8b, 0xc7, 0xff, 0xca, 0xaf, 0x1a, 0xb9, 0x52, 0x2d, 0x6d,
-	0x18, 0x34, 0xe8, 0xbf, 0x06, 0x5b, 0x67, 0xeb, 0x2b, 0x51, 0x7f, 0x25, 0xf1, 0x01, 0x45, 0x2a,
-	0xe6, 0x3f, 0xe7, 0x50, 0x14, 0x9d, 0x6f, 0x60, 0xd4, 0xef, 0x47, 0x6c, 0x30, 0x6f, 0x6e, 0xb1,
-	0xd1, 0x60, 0xf8, 0x09, 0x23, 0xc5, 0x43, 0x6c, 0x36, 0x78, 0xbd, 0xc1, 0x96, 0xc2, 0x10, 0x0f,
-	0x1a, 0xfc, 0xb8, 0xc1, 0x43, 0x85, 0x21, 0xb6, 0x1b, 0x5c, 0x51, 0xec, 0x10, 0x07, 0xac, 0xab,
-	0x9b, 0xb7, 0xf8, 0xe4, 0xfc, 0x0c, 0x06, 0x9b, 0x3b, 0xc1, 0x08, 0x80, 0xbd, 0x96, 0x65, 0x5a,
-	0x24, 0xd8, 0x20, 0x63, 0x70, 0xde, 0x17, 0x92, 0x25, 0xac, 0xc4, 0x68, 0x89, 0xef, 0xf7, 0x1e,
-	0xfa, 0xb1, 0xf7, 0xd0, 0xaf, 0xbd, 0x87, 0xbe, 0xff, 0xf6, 0x8c, 0xad, 0xad, 0xbe, 0xe7, 0xcb,
-	0x3f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x9d, 0x74, 0x8e, 0x36, 0xe7, 0x02, 0x00, 0x00,
-}
-
 func (m *PlacementRule) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -639,6 +607,23 @@ func (m *SFGroup) MarshalTo(dAtA []byte) (int, error) {
 			}
 			i += n
 		}
+	}
+	if len(m.Exclude) > 0 {
+		dAtA2 := make([]byte, len(m.Exclude)*10)
+		var j1 int
+		for _, num := range m.Exclude {
+			for num >= 1<<7 {
+				dAtA2[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA2[j1] = uint8(num)
+			j1++
+		}
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintSelector(dAtA, i, uint64(j1))
+		i += copy(dAtA[i:], dAtA2[:j1])
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -732,11 +717,11 @@ func (m *SimpleFilter) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintSelector(dAtA, i, uint64(m.Op))
 	}
 	if m.Args != nil {
-		nn1, err := m.Args.MarshalTo(dAtA[i:])
+		nn3, err := m.Args.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += nn1
+		i += nn3
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -758,11 +743,11 @@ func (m *SimpleFilter_FArgs) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintSelector(dAtA, i, uint64(m.FArgs.Size()))
-		n2, err := m.FArgs.MarshalTo(dAtA[i:])
+		n4, err := m.FArgs.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n4
 	}
 	return i, nil
 }
@@ -791,11 +776,11 @@ func (m *Filter) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintSelector(dAtA, i, uint64(m.F.Size()))
-		n3, err := m.F.MarshalTo(dAtA[i:])
+		n5, err := m.F.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n3
+		i += n5
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -850,6 +835,13 @@ func (m *SFGroup) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovSelector(uint64(l))
 		}
+	}
+	if len(m.Exclude) > 0 {
+		l = 0
+		for _, e := range m.Exclude {
+			l += sovSelector(uint64(e))
+		}
+		n += 1 + sovSelector(uint64(l)) + l
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -1159,6 +1151,79 @@ func (m *SFGroup) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType == 0 {
+				var v uint32
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowSelector
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= (uint32(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.Exclude = append(m.Exclude, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowSelector
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= (int(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthSelector
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.Exclude) == 0 {
+					m.Exclude = make([]uint32, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint32
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowSelector
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= (uint32(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.Exclude = append(m.Exclude, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exclude", wireType)
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipSelector(dAtA[iNdEx:])
@@ -1710,3 +1775,38 @@ var (
 	ErrInvalidLengthSelector = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowSelector   = fmt.Errorf("proto: integer overflow")
 )
+
+func init() { proto.RegisterFile("selector.proto", fileDescriptor_selector_514e26064bb83725) }
+
+var fileDescriptor_selector_514e26064bb83725 = []byte{
+	// 464 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x52, 0xcd, 0x6e, 0xd3, 0x40,
+	0x18, 0xf4, 0xda, 0x89, 0xdd, 0x7c, 0x21, 0x61, 0x59, 0x15, 0x64, 0x71, 0x70, 0x8d, 0x4f, 0x56,
+	0xa5, 0xba, 0x10, 0x38, 0x23, 0x35, 0x60, 0x17, 0x04, 0x6a, 0xca, 0x26, 0xe2, 0xee, 0x84, 0xc5,
+	0x58, 0x72, 0xbc, 0x2b, 0x7b, 0x2d, 0xd1, 0x1b, 0x37, 0x5e, 0x81, 0x47, 0xea, 0x91, 0x27, 0x40,
+	0x28, 0xbc, 0x08, 0xf2, 0xfa, 0x87, 0x28, 0xa2, 0xa7, 0xf1, 0x7c, 0xdf, 0xcc, 0xce, 0x37, 0x92,
+	0x61, 0x5a, 0xb2, 0x8c, 0x6d, 0x24, 0x2f, 0x02, 0x51, 0x70, 0xc9, 0x89, 0x99, 0x33, 0xb9, 0x8d,
+	0xc5, 0xe3, 0xb3, 0x24, 0x95, 0x5f, 0xaa, 0x75, 0xb0, 0xe1, 0xdb, 0xf3, 0x84, 0x27, 0xfc, 0x5c,
+	0xad, 0xd7, 0xd5, 0x67, 0xc5, 0x14, 0x51, 0x5f, 0x8d, 0xcd, 0x5b, 0xc3, 0xe4, 0x3a, 0x8b, 0x37,
+	0x6c, 0xcb, 0x72, 0x49, 0xab, 0x8c, 0x11, 0x07, 0x80, 0x32, 0x91, 0x45, 0x71, 0xfd, 0xb6, 0x8d,
+	0x5c, 0xe4, 0x4f, 0xe8, 0xde, 0x84, 0x3c, 0x83, 0xa3, 0x65, 0x74, 0x59, 0xf0, 0x4a, 0x94, 0xb6,
+	0xee, 0x1a, 0xfe, 0x78, 0x76, 0x3f, 0x68, 0xa2, 0x83, 0x76, 0x3e, 0x1f, 0xdc, 0xfe, 0x3a, 0xd1,
+	0x68, 0x2f, 0xf3, 0xbe, 0x23, 0xb0, 0x5a, 0x42, 0x02, 0xb0, 0xa2, 0x34, 0x93, 0xac, 0x28, 0x6d,
+	0xa4, 0xdc, 0xd3, 0xce, 0xdd, 0x8c, 0x5b, 0x73, 0x27, 0x22, 0x33, 0x18, 0x2d, 0xdb, 0xa2, 0x5d,
+	0x5e, 0xef, 0x68, 0x16, 0xad, 0xe3, 0x9f, 0x8c, 0xd8, 0x60, 0x85, 0x5f, 0x37, 0x59, 0xf5, 0x89,
+	0xd9, 0x86, 0x6b, 0xf8, 0x13, 0xda, 0x51, 0xef, 0x29, 0x98, 0x8d, 0x8c, 0x1c, 0xc3, 0xf0, 0x15,
+	0xaf, 0x72, 0xd9, 0x36, 0x6c, 0x08, 0xc1, 0x60, 0xbc, 0x63, 0x37, 0xb6, 0xee, 0x22, 0x7f, 0x44,
+	0xeb, 0x4f, 0x2f, 0x84, 0xc9, 0x32, 0xdd, 0x8a, 0x8c, 0x75, 0x07, 0xbd, 0x38, 0x2c, 0x70, 0xdc,
+	0x9f, 0xb3, 0xa7, 0x3b, 0xa8, 0xe1, 0x7d, 0x43, 0x70, 0x6f, 0x7f, 0x4f, 0x9e, 0x80, 0xbe, 0x10,
+	0x2a, 0x7c, 0x3a, 0x7b, 0xd0, 0xbd, 0xb0, 0x10, 0xac, 0x88, 0x65, 0xca, 0x73, 0xaa, 0x2f, 0x04,
+	0x79, 0x04, 0xc3, 0x8f, 0x71, 0x56, 0xb1, 0xe6, 0x9c, 0x37, 0x1a, 0x6d, 0x28, 0x39, 0x83, 0x61,
+	0x74, 0x51, 0x24, 0xa5, 0x6d, 0xb8, 0xc8, 0x1f, 0xcf, 0x1e, 0xfe, 0x2f, 0xbf, 0xac, 0xe5, 0x4a,
+	0x35, 0x37, 0x61, 0x50, 0xa3, 0xf7, 0x12, 0xcc, 0x36, 0xbb, 0x6d, 0x89, 0xfa, 0x96, 0xc4, 0x03,
+	0x14, 0xa9, 0x98, 0x3b, 0xea, 0x50, 0x14, 0x9d, 0xae, 0x60, 0xd4, 0xdf, 0x47, 0x4c, 0xd0, 0xaf,
+	0xae, 0xb1, 0x56, 0x63, 0xf8, 0x01, 0x23, 0xc5, 0x43, 0xac, 0xd7, 0x78, 0xb9, 0xc2, 0x86, 0xc2,
+	0x10, 0x0f, 0x6a, 0x7c, 0xbf, 0xc2, 0x43, 0x85, 0x21, 0x36, 0x6b, 0x5c, 0x50, 0x6c, 0x11, 0x0b,
+	0x8c, 0x8b, 0xab, 0xd7, 0xf8, 0xe8, 0xf4, 0x04, 0x06, 0xab, 0x1b, 0xc1, 0x08, 0x80, 0xb9, 0x94,
+	0x45, 0x9a, 0x27, 0x58, 0x23, 0x63, 0xb0, 0xde, 0xe6, 0x92, 0x25, 0xac, 0xc0, 0x68, 0x8e, 0x6f,
+	0x77, 0x0e, 0xfa, 0xb9, 0x73, 0xd0, 0xef, 0x9d, 0x83, 0x7e, 0xfc, 0x71, 0xb4, 0xb5, 0xa9, 0xfe,
+	0xdc, 0xe7, 0x7f, 0x03, 0x00, 0x00, 0xff, 0xff, 0xe7, 0x59, 0x33, 0x15, 0x02, 0x03, 0x00, 0x00,
+}

--- a/selector.proto
+++ b/selector.proto
@@ -24,6 +24,7 @@ message PlacementRule {
 message SFGroup {
     repeated Filter Filters = 1 [(gogoproto.nullable) = false];
     repeated Select Selectors = 2 [(gogoproto.nullable) = false];
+    repeated uint32 Exclude = 3;
 }
 
 message Select {


### PR DESCRIPTION
Individual nodes that are undesired in placement graph can be specified via `Exclude`