### PR TITLE
Add mean price aggregator for IQR

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -1,5 +1,9 @@
 package netmap
 
+import (
+	"sort"
+)
+
 type (
 	// Aggregator can calculate some value across all netmap
 	// such as median, minimum or maximum.
@@ -27,6 +31,11 @@ type (
 		min uint64
 	}
 
+	meanPriceIQRAgg struct {
+		k   float64
+		arr []uint64
+	}
+
 	reverseMinNorm struct {
 		min float64
 	}
@@ -47,6 +56,7 @@ var (
 	_ Aggregator = (*meanCapSumAgg)(nil)
 	_ Aggregator = (*meanCapAgg)(nil)
 	_ Aggregator = (*minPriceAgg)(nil)
+	_ Aggregator = (*meanPriceIQRAgg)(nil)
 
 	_ Normalizer = (*reverseMinNorm)(nil)
 	_ Normalizer = (*sigmoidNorm)(nil)
@@ -109,6 +119,39 @@ func (a *minPriceAgg) Add(n Node) {
 
 func (a *minPriceAgg) Compute() float64 {
 	return float64(a.min)
+}
+
+func (a *meanPriceIQRAgg) Add(n Node) {
+	a.arr = append(a.arr, n.P)
+}
+
+func (a *meanPriceIQRAgg) Compute() float64 {
+	l := len(a.arr)
+	if l == 0 {
+		return 0
+	}
+
+	sort.Slice(a.arr, func(i, j int) bool { return a.arr[i] < a.arr[j] })
+
+	var min, max float64
+	if l < 4 {
+		min, max = float64(a.arr[0]), float64(a.arr[l-1])
+	} else {
+		start, end := l/4, l*3/4-1
+		iqr := a.k * float64(a.arr[end]-a.arr[start])
+		min, max = float64(a.arr[start])-iqr, float64(a.arr[end])+iqr
+	}
+
+	count := 0
+	sum := float64(0)
+	for _, e := range a.arr {
+		t := float64(e)
+		if t >= min && t <= max {
+			sum += float64(t)
+			count++
+		}
+	}
+	return sum / float64(count)
 }
 
 func (r *reverseMinNorm) Normalize(w float64) float64 {

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -66,6 +66,33 @@ func TestAggregator_Compute(t *testing.T) {
 	a = new(minPriceAgg)
 	b.Traverse(a)
 	require.InEpsilon(t, 1.0, a.Compute(), eps)
+
+	a = new(meanPriceIQRAgg)
+	b.Traverse(a)
+	require.InEpsilon(t, 2.0, a.Compute(), eps)
+
+	mp := new(meanPriceIQRAgg)
+	nodes := []Node{{P: 1}, {P: 1}, {P: 10}, {P: 3}, {P: 5}, {P: 5}, {P: 1}, {P: 100}}
+	for i := range nodes {
+		mp.Add(nodes[i])
+	}
+
+	mp.k = 0.5
+	require.InEpsilon(t, 2.666, mp.Compute(), eps)
+
+	mp.k = 1.5
+	require.InEpsilon(t, 3.714, mp.Compute(), eps)
+
+	mp.k = 23.0
+	require.InEpsilon(t, 3.714, mp.Compute(), eps)
+
+	mp.k = 24.0
+	require.InEpsilon(t, 15.75, mp.Compute(), eps)
+
+	mp = new(meanPriceIQRAgg)
+	mp.Add(Node{P: 1})
+	mp.Add(Node{P: 101})
+	require.InEpsilon(t, 51.0, mp.Compute(), eps)
 }
 
 func TestSigmoidNorm_Normalize(t *testing.T) {


### PR DESCRIPTION
Mean price value involving only interquartile range can
be useful as a way to deal with outliers.