### PR TITLE
Compute weights for every Bucket

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -8,8 +8,9 @@ type (
 	// Aggregator can calculate some value across all netmap
 	// such as median, minimum or maximum.
 	Aggregator interface {
-		Add(Node)
+		Add(float64)
 		Compute() float64
+		Clear()
 	}
 
 	// Normalizer normalizes weight.
@@ -17,23 +18,23 @@ type (
 		Normalize(w float64) float64
 	}
 
-	meanCapSumAgg struct {
-		sum   uint64
+	meanSumAgg struct {
+		sum   float64
 		count int
 	}
 
-	meanCapAgg struct {
+	meanAgg struct {
 		mean  float64
 		count int
 	}
 
-	minPriceAgg struct {
-		min uint64
+	minAgg struct {
+		min float64
 	}
 
-	meanPriceIQRAgg struct {
+	meanIQRAgg struct {
 		k   float64
-		arr []uint64
+		arr []float64
 	}
 
 	reverseMinNorm struct {
@@ -53,82 +54,67 @@ type (
 )
 
 var (
-	_ Aggregator = (*meanCapSumAgg)(nil)
-	_ Aggregator = (*meanCapAgg)(nil)
-	_ Aggregator = (*minPriceAgg)(nil)
-	_ Aggregator = (*meanPriceIQRAgg)(nil)
+	_ Aggregator = (*meanSumAgg)(nil)
+	_ Aggregator = (*meanAgg)(nil)
+	_ Aggregator = (*minAgg)(nil)
+	_ Aggregator = (*meanIQRAgg)(nil)
 
 	_ Normalizer = (*reverseMinNorm)(nil)
 	_ Normalizer = (*sigmoidNorm)(nil)
 	_ Normalizer = (*constNorm)(nil)
 )
 
-// CapWeightFunc calculates weight which is equal to capacity.
-func CapWeightFunc(n Node) float64 { return float64(n.C) }
-
-// NewWeightFunc returns WeightFunc which multiplies normalized
-// capacity and price.
-// TODO generic solution for arbitrary number of weights
-func NewWeightFunc(capNorm, priceNorm Normalizer) WeightFunc {
-	return func(n Node) float64 {
-		return capNorm.Normalize(float64(n.C)) * priceNorm.Normalize(float64(n.P))
-	}
-}
-
-func getDefaultWeightFunc(ns Nodes) WeightFunc {
-	agg := new(meanCapAgg)
-	for i := range ns {
-		agg.Add(ns[i])
-	}
-	// TODO replace constNorm for price with minPriceAgg when ready
-	return NewWeightFunc(&sigmoidNorm{agg.Compute()}, &constNorm{1})
-}
-
-// Traverse adds all Bucket nodes to a and returns it's argument.
-func (b *Bucket) Traverse(a Aggregator) Aggregator {
-	for i := range b.nodes {
-		a.Add(b.nodes[i])
-	}
-	return a
-}
-
-func (a *meanCapSumAgg) Add(n Node) {
-	a.sum += n.C
+func (a *meanSumAgg) Add(n float64) {
+	a.sum += n
 	a.count++
 }
 
-func (a *meanCapSumAgg) Compute() float64 {
+func (a *meanSumAgg) Compute() float64 {
 	if a.count == 0 {
 		return 0
 	}
 	return float64(a.sum) / float64(a.count)
 }
 
-func (a *meanCapAgg) Add(n Node) {
+func (a *meanSumAgg) Clear() {
+	a.sum = 0
+	a.count = 0
+}
+
+func (a *meanAgg) Add(n float64) {
 	c := a.count + 1
-	a.mean = a.mean*(float64(a.count)/float64(c)) + float64(n.C)/float64(c)
+	a.mean = a.mean*(float64(a.count)/float64(c)) + float64(n)/float64(c)
 	a.count++
 }
 
-func (a *meanCapAgg) Compute() float64 {
+func (a *meanAgg) Compute() float64 {
 	return a.mean
 }
 
-func (a *minPriceAgg) Add(n Node) {
-	if a.min == 0 || n.P < a.min {
-		a.min = n.P
+func (a *meanAgg) Clear() {
+	a.count = 0
+	a.mean = 0
+}
+
+func (a *minAgg) Add(n float64) {
+	if a.min == 0 || n < a.min {
+		a.min = n
 	}
 }
 
-func (a *minPriceAgg) Compute() float64 {
+func (a *minAgg) Compute() float64 {
 	return float64(a.min)
 }
 
-func (a *meanPriceIQRAgg) Add(n Node) {
-	a.arr = append(a.arr, n.P)
+func (a *minAgg) Clear() {
+	a.min = 0
 }
 
-func (a *meanPriceIQRAgg) Compute() float64 {
+func (a *meanIQRAgg) Add(n float64) {
+	a.arr = append(a.arr, n)
+}
+
+func (a *meanIQRAgg) Compute() float64 {
 	l := len(a.arr)
 	if l == 0 {
 		return 0
@@ -138,23 +124,26 @@ func (a *meanPriceIQRAgg) Compute() float64 {
 
 	var min, max float64
 	if l < 4 {
-		min, max = float64(a.arr[0]), float64(a.arr[l-1])
+		min, max = a.arr[0], a.arr[l-1]
 	} else {
 		start, end := l/4, l*3/4-1
-		iqr := a.k * float64(a.arr[end]-a.arr[start])
-		min, max = float64(a.arr[start])-iqr, float64(a.arr[end])+iqr
+		iqr := a.k * (a.arr[end] - a.arr[start])
+		min, max = a.arr[start]-iqr, a.arr[end]+iqr
 	}
 
 	count := 0
 	sum := float64(0)
 	for _, e := range a.arr {
-		t := float64(e)
-		if t >= min && t <= max {
-			sum += float64(t)
+		if e >= min && e <= max {
+			sum += e
 			count++
 		}
 	}
 	return sum / float64(count)
+}
+
+func (a *meanIQRAgg) Clear() {
+	a.arr = a.arr[:0]
 }
 
 func (r *reverseMinNorm) Normalize(w float64) float64 {

--- a/aggregator.go
+++ b/aggregator.go
@@ -64,6 +64,31 @@ var (
 	_ Normalizer = (*constNorm)(nil)
 )
 
+// NewMeanSumAgg returns an aggregator which
+// computes mean value by keeping total sum.
+func NewMeanSumAgg() Aggregator {
+	return new(meanSumAgg)
+}
+
+// NewMeanAgg returns an aggregator which
+// computes mean value by recalculating it on
+// every addition.
+func NewMeanAgg() Aggregator {
+	return new(meanAgg)
+}
+
+// NewMinAgg returns an aggregator which
+// computes min value.
+func NewMinAgg() Aggregator {
+	return new(minAgg)
+}
+
+// NewMeanIQRAgg returns an aggregator which
+// computes mean value of values from IQR interval.
+func NewMeanIQRAgg() Aggregator {
+	return new(meanIQRAgg)
+}
+
 func (a *meanSumAgg) Add(n float64) {
 	a.sum += n
 	a.count++

--- a/policy.go
+++ b/policy.go
@@ -383,7 +383,15 @@ func (b Bucket) GetSelection(ss []Select, pivot []byte) *Bucket {
 
 	cs = getChildrenByKey(b, ss[0])
 	if len(pivot) != 0 {
-		hrw.SortSliceByValue(cs, pivotHash)
+		if b.weight == 0 {
+			hrw.SortSliceByValue(cs, pivotHash)
+		} else {
+			weights := make([]float64, len(cs))
+			for i := range weights {
+				weights[i] = cs[i].weight
+			}
+			hrw.SortSliceByWeightValue(cs, weights, pivotHash)
+		}
 	}
 	for i := 0; i < len(cs); i++ {
 		if r = cs[i].GetSelection(ss[1:], pivot); r != nil {

--- a/policy.go
+++ b/policy.go
@@ -183,11 +183,11 @@ func (b *Bucket) findNodes(pivot []byte, s SFGroup) Nodes {
 }
 
 // Copy returns deep copy of Bucket.
-func (b Bucket) Copy() Bucket {
-	var bc = Bucket{
-		Key:   b.Key,
-		Value: b.Value,
-	}
+func (b Bucket) Copy() (bc Bucket) {
+	bc.weight = b.weight
+	bc.Key = b.Key
+	bc.Value = b.Value
+
 	if b.nodes != nil {
 		bc.nodes = make(Nodes, len(b.nodes))
 		copy(bc.nodes, b.nodes)

--- a/policy.go
+++ b/policy.go
@@ -31,6 +31,7 @@ type (
 	Bucket struct {
 		Key      string
 		Value    string
+		weight   float64
 		nodes    Nodes
 		children []Bucket
 	}
@@ -587,9 +588,9 @@ func (b Bucket) Name() string {
 
 func (b *Bucket) fillNodes() {
 	r := b.nodes
-	for _, c := range b.children {
-		c.fillNodes()
-		r = merge(r, c.Nodelist())
+	for i := range b.children {
+		b.children[i].fillNodes()
+		r = merge(r, b.children[i].Nodelist())
 	}
 	b.nodes = r
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -314,7 +314,7 @@ func TestBucket_GetWeightSelection(t *testing.T) {
 	root, err = newStrawRoot(buckets...)
 	require.NoError(t, err)
 
-	nodes = Nodes{{N: 25, C: 8}, {N: 20, C: 9}, {N: 3, C: 3}, {N: 30, C: 10}}
+	nodes = Nodes{{N: 26, C: 1}, {N: 1, C: 1}, {N: 25, C: 8}, {N: 27, C: 1}}
 
 	ss = []Select{
 		{Key: NodesBucket, Count: 4},
@@ -329,7 +329,7 @@ func TestBucket_GetWeightSelection(t *testing.T) {
 		{Key: NodesBucket, Count: 1},
 	}
 
-	nodes = Nodes{{N: 18, C: 1}, {N: 25, C: 8}, {N: 29, C: 2}, {N: 30, C: 10}}
+	nodes = Nodes{{N: 18, C: 1}, {N: 25, C: 8}, {N: 26, C: 1}, {N: 27, C: 1}}
 	r = root.GetSelection(ss, defaultPivot)
 	require.NotNil(t, r)
 	require.Equal(t, r.Nodelist(), nodes)

--- a/weight.go
+++ b/weight.go
@@ -23,12 +23,13 @@ func NewWeightFunc(capNorm, priceNorm Normalizer) WeightFunc {
 }
 
 func getDefaultWeightFunc(ns Nodes) WeightFunc {
-	agg := new(meanAgg)
+	mean := new(meanAgg)
+	min := new(minAgg)
 	for i := range ns {
-		agg.Add(float64(ns[i].C))
+		mean.Add(float64(ns[i].C))
+		min.Add(float64(ns[i].P))
 	}
-	// TODO replace constNorm for price with minAgg when ready
-	return NewWeightFunc(&sigmoidNorm{agg.Compute()}, &constNorm{1})
+	return NewWeightFunc(&sigmoidNorm{mean.Compute()}, &reverseMinNorm{min.Compute()})
 }
 
 // Traverse adds all Bucket nodes to a and returns it's argument.

--- a/weight.go
+++ b/weight.go
@@ -1,0 +1,53 @@
+package netmap
+
+type (
+	// AggregatorFactory is a Factory for a specific Aggregator
+	AggregatorFactory struct {
+		New func() Aggregator
+	}
+)
+
+// CapWeightFunc calculates weight which is equal to capacity.
+func CapWeightFunc(n Node) float64 { return float64(n.C) }
+
+// PriceWeightFunc calculates weight which is equal to price.
+func PriceWeightFunc(n Node) float64 { return float64(n.P) }
+
+// NewWeightFunc returns WeightFunc which multiplies normalized
+// capacity and price.
+// TODO generic solution for arbitrary number of weights
+func NewWeightFunc(capNorm, priceNorm Normalizer) WeightFunc {
+	return func(n Node) float64 {
+		return capNorm.Normalize(float64(n.C)) * priceNorm.Normalize(float64(n.P))
+	}
+}
+
+func getDefaultWeightFunc(ns Nodes) WeightFunc {
+	agg := new(meanAgg)
+	for i := range ns {
+		agg.Add(float64(ns[i].C))
+	}
+	// TODO replace constNorm for price with minAgg when ready
+	return NewWeightFunc(&sigmoidNorm{agg.Compute()}, &constNorm{1})
+}
+
+// Traverse adds all Bucket nodes to a and returns it's argument.
+func (b *Bucket) Traverse(a Aggregator, wf WeightFunc) Aggregator {
+	for i := range b.nodes {
+		a.Add(wf(b.nodes[i]))
+	}
+	return a
+}
+
+// TraverseTree computes weight for every Bucket and all of its children.
+func (b *Bucket) TraverseTree(af AggregatorFactory, wf WeightFunc) {
+	a := af.New()
+	for i := range b.nodes {
+		a.Add(wf(b.nodes[i]))
+	}
+	b.weight = a.Compute()
+
+	for i := range b.children {
+		b.children[i].TraverseTree(af, wf)
+	}
+}


### PR DESCRIPTION
During HRW it can be beneficial to have weight on every level of
Bucket-tree. This commit adds such a possibility.

There are 2 orthogonal choices to be made:
1. Hierarchical structure
  - compute a weight of Bucket based on weight from it’s children Buckets
  - compute a weight of Bucket based solely on nodes it contain (flattening the tree).
2. Weight number
  - compute a single weight for every bucket
  - compute multiple weights (“base” weights) for every bucket, combining these in different ways when needed (think about separate weights for `Capacity` and `Price`)

This PR implements 1b+2a approach as it is the simplest.