### PR TITLE
Remove division by zero

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -98,6 +98,9 @@ func (a *meanCapSumAgg) Add(n Node) {
 }
 
 func (a *meanCapSumAgg) Compute() float64 {
+	if a.count == 0 {
+		return 0
+	}
 	return float64(a.sum) / float64(a.count)
 }
 
@@ -162,6 +165,9 @@ func (r *reverseMinNorm) Normalize(w float64) float64 {
 }
 
 func (r *sigmoidNorm) Normalize(w float64) float64 {
+	if r.scale == 0 {
+		return 0
+	}
 	x := w / r.scale
 	return x / (1 + x)
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -2,6 +2,7 @@ package netmap
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -959,6 +960,33 @@ func TestBucket_FindNodes(t *testing.T) {
 	nscopy := root.FindNodes(defaultPivot, SFGroup{Selectors: ss})
 	require.Len(t, nscopy, 3)
 	require.Equal(t, ns, nscopy)
+}
+
+func TestNodes_Weight(t *testing.T) {
+	var N Nodes
+	t.Run("empty weights", func(t *testing.T) {
+		N = Nodes{{N: 0}, {N: 1}, {N: 2}, {N: 3}, {N: 4}}
+		for _, weight := range N.Weights() {
+			require.False(t, math.IsNaN(weight))
+			require.Equal(t, 0.0, weight)
+		}
+	})
+	t.Run(" non empty uniform weight", func(t *testing.T) {
+		N = Nodes{{N: 0, C: 2, P: 1}, {N: 1, C: 2, P: 1}, {N: 2, C: 2, P: 1}, {N: 3, C: 2, P: 1}, {N: 4, C: 2, P: 1}}
+		for _, weight := range N.Weights() {
+			require.False(t, math.IsNaN(weight))
+			require.Equal(t, 0.5, weight)
+		}
+	})
+	t.Run(" non empty non uniform weight", func(t *testing.T) {
+		N = Nodes{{N: 0, C: 20, P: 1}, {N: 1, C: 1, P: 1}, {N: 2, C: 30, P: 1}, {N: 3, C: 100, P: 1}, {N: 4, C: 42, P: 1}}
+		var prev float64
+		for _, weight := range N.Weights() {
+			require.False(t, math.IsNaN(weight))
+			require.False(t, prev == weight)
+			prev = weight
+		}
+	})
 }
 
 func TestBucket_NewOption(t *testing.T) {


### PR DESCRIPTION
If nodes don't set capacities, aggregate capacity value is 0 and it
leads to division by zero. There is no panic since float has NaN value,
but NaN isn't working with float arithmetic. HRW and Netmap libraries
don't handle NaN therefore it leads to incorrect behaviour.